### PR TITLE
Switch API routes to Next.js default handler

### DIFF
--- a/pages/api/galleries.ts
+++ b/pages/api/galleries.ts
@@ -1,19 +1,17 @@
 // File: pages/api/galleries.ts
 
-import type { NextRequest } from 'next/server'
+import type { NextApiRequest, NextApiResponse } from 'next'
 import { getDb } from '../../lib/db'
 
-export async function GET(
-  request: NextRequest,
-  { env }: { env: any }    // ← inline type to satisfy TS for now
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
 ) {
-  const db = getDb(env)
+  const db = getDb(process.env as any)
   const { results } = await db
     .prepare(`SELECT * FROM galleries`)
     .all()
 
-  return new Response(JSON.stringify(results), {
-    headers: { 'Content-Type': 'application/json' },
-  })
+  res.status(200).json(results)
 }
 

--- a/pages/api/images.ts
+++ b/pages/api/images.ts
@@ -1,21 +1,18 @@
 // File: pages/api/images.ts
 
-import type { NextRequest } from 'next/server'
+import type { NextApiRequest, NextApiResponse } from 'next'
 import { getDb } from '../../lib/db'
 
-export async function GET(
-  request: NextRequest,
-  { env }: { env: any }    // ← inline type to satisfy TS for now
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
 ) {
-  const url     = new URL(request.url)
-  const gallery = url.searchParams.get('gallery')
-  const db      = getDb(env)
+  const { gallery } = req.query
+  const db = getDb(process.env as any)
 
-  if (!gallery) {
-    return new Response(JSON.stringify({ error: 'Missing gallery parameter' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    })
+  if (!gallery || typeof gallery !== 'string') {
+    res.status(400).json({ error: 'Missing gallery parameter' })
+    return
   }
 
   const { results } = await db
@@ -23,8 +20,6 @@ export async function GET(
     .bind(gallery)
     .all()
 
-  return new Response(JSON.stringify(results), {
-    headers: { 'Content-Type': 'application/json' },
-  })
+  res.status(200).json(results)
 }
 


### PR DESCRIPTION
## Summary
- use `NextApiRequest`/`NextApiResponse` in the `images` and `galleries` API routes
- read query params from `req` and send JSON via `res`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d782c9788323be801f55c4807028