### PR TITLE
Switch gallery API to JIMI_DB

### DIFF
--- a/pages/api/gallery.ts
+++ b/pages/api/gallery.ts
@@ -4,7 +4,7 @@ export const config = {
 
 export default async function handler(req: Request, ctx: any) {
   try {
-    const db = ctx.env.DB;
+    const db = ctx.env.JIMI_DB;
 
     const result = await db
       .prepare("SELECT id, slug, title, style, url, created_at FROM gallery_sketches ORDER BY created_at DESC")


### PR DESCRIPTION
## Summary
- point gallery API to `JIMI_DB` binding

## Testing
- `sqlite3 test.db < schema.sql`
- `sqlite3 test.db "INSERT INTO gallery_sketches (slug, title, style, url) VALUES ('slug1', 'Title 1', 'Style 1', 'http://example.com');"`
- `sqlite3 test.db "INSERT INTO gallery_sketches (slug, title, style, url) VALUES ('slug2', 'Title 2', 'Style 2', 'http://example2.com');"`
- `sqlite3 test.db "SELECT id, slug, title, style, url, created_at FROM gallery_sketches ORDER BY created_at DESC;"`

------
https://chatgpt.com/codex/tasks/task_e_684dc5804c688323b6661952fb4fc79c