### PR TITLE
Update gallery endpoints to use gallery_sketches

### DIFF
--- a/pages/api/gallery.ts
+++ b/pages/api/gallery.ts
@@ -10,7 +10,8 @@ export default async function GET(request: NextRequest) {
   const url = new URL(request.url);
   const galleryParam = url.searchParams.get("gallery")?.trim();
 
-  const tableName = "sketches";  // adjust if needed
+  // query gallery entries from the new table
+  const tableName = "gallery_sketches";
 
   let baseQuery = `
     SELECT slug AS id, title, gallery, file_key

--- a/pages/api/images.ts
+++ b/pages/api/images.ts
@@ -9,9 +9,9 @@ export default async function handler(request: NextRequest) {
   const { env } = getCloudflareContext();
 
   try {
-    // Adjust your table name if needed
+    // Fetch records from the gallery_sketches table
     const { results } = await env.JIMI_DB
-      .prepare("SELECT * FROM images")
+      .prepare("SELECT * FROM gallery_sketches")
       .all();
 
     return NextResponse.json(results);

--- a/pages/api/uploads.ts
+++ b/pages/api/uploads.ts
@@ -50,9 +50,9 @@ export default async function handler(request: NextRequest) {
       httpMetadata: { contentType: file.type },
     });
 
-    // Insert metadata into D1 (adjust table & columns as needed)
+    // Insert metadata into D1 using the gallery_sketches table
     await env.JIMI_DB.prepare(
-      `INSERT INTO sketches (slug, title, gallery, file_key, notes, black_and_white)
+      `INSERT INTO gallery_sketches (slug, title, gallery, file_key, notes, black_and_white)
        VALUES (?, ?, ?, ?, ?, ?)`
     ).bind(key, title, style, key, notes, blackAndWhite ? 1 : 0).run();
 


### PR DESCRIPTION
## Summary
- point gallery API at the new `gallery_sketches` table
- store uploads in `gallery_sketches`
- read from `gallery_sketches` in images API

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d9fe12d48323b210a33ff3a68e9d