### PR TITLE
Add sketches API route

### DIFF
--- a/pages/api/sketches.ts
+++ b/pages/api/sketches.ts
@@ -1,0 +1,20 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export default async function handler(request: NextRequest) {
+  const { env } = getCloudflareContext();
+  try {
+    const { results } = await env.JIMI_DB
+      .prepare("SELECT * FROM gallery_sketches ORDER BY created_at DESC")
+      .all();
+
+    return NextResponse.json({ ok: true, sketches: results });
+  } catch (err: any) {
+    console.error("Error fetching sketches:", err);
+    return NextResponse.json(
+      { ok: false, error: err.message || "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add missing `/api/sketches` endpoint returning gallery sketches

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850de4045c4832394021bee346f76b9