### PR TITLE
Fix OpenNext wrapper configuration

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,4 +1,8 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+
+// Use the workers wrapper which is one of the valid options in
+// OpenNext 3.1.3. Other supported wrappers include aws-lambda,
+// aws-lambda-edge, cloudflare, cloudflare-pages and netlify.
 export default defineCloudflareConfig({
-  wrapper: "cloudflare-pages",
+  wrapper: "cloudflare-workers",
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
 name            = "prisim"
 account_id      = "698917d9ae04da2587d19eaae5bcef5c"
+pages_build_output_dir = ".open-next"
 compatibility_date = "2025-06-16"
 compatibility_flags = ["nodejs_compat","global_fetch_strictly_public"]
 


### PR DESCRIPTION
## Summary
- switch to the `cloudflare-workers` wrapper for OpenNext
- add `pages_build_output_dir` to Cloudflare `wrangler.toml`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694cfdce8483238adbd7bee138a321