### PR TITLE
Add Next.js API routes for local dev

### DIFF
--- a/pages/api/gallery.ts
+++ b/pages/api/gallery.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const env: any = (global as any).env || {};
+
+  if (req.method !== "GET") {
+    res.status(405).send("Method Not Allowed");
+    return;
+  }
+
+  if (!env.JIMI_DB || typeof env.JIMI_DB.prepare !== "function") {
+    res.status(500).json({ error: "Database not configured" });
+    return;
+  }
+
+  const gallery = req.query.gallery as string | undefined;
+
+  try {
+    let stmt: any;
+    if (gallery) {
+      stmt = env.JIMI_DB.prepare(`
+        SELECT id, slug, title, style, notes, black_and_white, created_at, url, gallery
+        FROM gallery_sketches
+        WHERE gallery = ?
+        ORDER BY created_at DESC
+      `).bind(gallery);
+    } else {
+      stmt = env.JIMI_DB.prepare(`
+        SELECT id, slug, title, style, notes, black_and_white, created_at, url, gallery
+        FROM gallery_sketches
+        ORDER BY created_at DESC
+      `);
+    }
+    const { results } = await stmt.all();
+    res.status(200).json(results);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message || "Server error" });
+  }
+}

--- a/pages/api/images.ts
+++ b/pages/api/images.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const env: any = (global as any).env || {};
+
+  if (req.method !== "GET") {
+    res.status(405).send("Method Not Allowed");
+    return;
+  }
+
+  if (!env.JIMI_DB || typeof env.JIMI_DB.prepare !== "function") {
+    res.status(500).json({ error: "Database not configured" });
+    return;
+  }
+
+  const gallery = req.query.gallery as string | undefined;
+
+  try {
+    let stmt: any;
+    if (gallery) {
+      stmt = env.JIMI_DB.prepare(`
+        SELECT i.id, i.url, COALESCE(i.title, '') AS title, g.slug AS gallery
+        FROM images i
+        JOIN gallery_images gi ON gi.image_id = i.id
+        JOIN galleries g ON g.id = gi.gallery_id
+        WHERE g.slug = ?
+        ORDER BY gi.position, i.created_at DESC
+      `).bind(gallery);
+    } else {
+      stmt = env.JIMI_DB.prepare(`
+        SELECT i.id, i.url, COALESCE(i.title, '') AS title, g.slug AS gallery
+        FROM images i
+        JOIN gallery_images gi ON gi.image_id = i.id
+        JOIN galleries g ON g.id = gi.gallery_id
+        ORDER BY g.name, gi.position, i.created_at DESC
+      `);
+    }
+    const { results } = await stmt.all();
+    res.status(200).json(results);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message || "Server error" });
+  }
+}

--- a/pages/api/sketches.ts
+++ b/pages/api/sketches.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const env: any = (global as any).env || {};
+
+  if (req.method !== "GET") {
+    res.status(405).send("Method Not Allowed");
+    return;
+  }
+
+  if (!env.JIMI_DB || typeof env.JIMI_DB.prepare !== "function") {
+    res.status(500).json({ ok: false, error: "Database not configured" });
+    return;
+  }
+
+  try {
+    const stmt = env.JIMI_DB.prepare(`
+      SELECT id, slug, title, style, black_and_white, notes, url, created_at, gallery
+      FROM gallery_sketches
+      ORDER BY created_at DESC
+    `);
+    const { results: sketches } = await stmt.all();
+    res.status(200).json({ ok: true, sketches });
+  } catch (err: any) {
+    res.status(500).json({ ok: false, error: err.message || "Server error" });
+  }
+}


### PR DESCRIPTION
## Summary
- add Next.js handlers for gallery, images and sketches APIs

## Testing
- `npm run dev` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adeb521448323beae1d387859c30c