### PR TITLE
Add cover image key to galleries

### DIFF
--- a/migrations/004_add_gallery_cover_key.sql
+++ b/migrations/004_add_gallery_cover_key.sql
@@ -1,0 +1,2 @@
+-- 004_add_gallery_cover_key.sql
+ALTER TABLE galleries ADD COLUMN cover_key TEXT;

--- a/pages/api/gallery.ts
+++ b/pages/api/gallery.ts
@@ -7,6 +7,7 @@ type GalleryRow = {
   slug: string;
   title: string;
   description: string;
+  cover_key: string | null;
   created_at: number;
 };
 type CreateGalleryBody = {
@@ -30,7 +31,7 @@ export default async function handler(req: Request): Promise<Response> {
 
     if (req.method === "GET") {
       const { results } = await DB.prepare(
-        "SELECT id, slug, title, description, created_at FROM galleries ORDER BY created_at DESC"
+        "SELECT id, slug, title, description, cover_key, created_at FROM galleries ORDER BY created_at DESC"
       ).all();
       return json(results as GalleryRow[]);
     }

--- a/pages/gallery/index.tsx
+++ b/pages/gallery/index.tsx
@@ -26,7 +26,7 @@ function coerceGalleries(x: unknown): Gallery[] {
         description:
           typeof obj.description === 'string' ? obj.description : null,
         coverKey:
-          typeof obj.coverKey === 'string' ? obj.coverKey : null,
+          typeof obj.cover_key === 'string' ? obj.cover_key : null,
       } as Gallery;
     })
     .filter(Boolean) as Gallery[];


### PR DESCRIPTION
## Summary
- add `cover_key` column to galleries for optional cover images
- return `cover_key` from gallery API
- use `cover_key` to build cover image source in gallery list

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Page /gallery/[slug] provided runtime 'edge', the edge runtime for rendering is currently experimental. Use runtime 'experimental-edge' instead.)*

------
https://chatgpt.com/codex/tasks/task_e_68bde4da8ed48323abb3e8109f6cd011