### PR TITLE
Switch gallery pages to experimental edge runtime

### DIFF
--- a/pages/api/images.ts
+++ b/pages/api/images.ts
@@ -1,5 +1,5 @@
 // pages/api/images.ts
-export const runtime = 'edge';
+export const runtime = 'experimental-edge';
 
 type Env = {
   // change only if your binding name is different in wrangler/pages settings

--- a/pages/gallery/[slug].tsx
+++ b/pages/gallery/[slug].tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
-export const runtime = 'edge';
+export const runtime = 'experimental-edge';
 
 type ImageRow = {
   id: string;

--- a/pages/gallery/index.tsx
+++ b/pages/gallery/index.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
-export const runtime = 'edge';
+export const runtime = 'experimental-edge';
 
 type Gallery = {
   id?: string;


### PR DESCRIPTION
## Summary
- use `experimental-edge` runtime for gallery listing, detail page, and images API

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bde705983883238d28cbb1af20d614