### PR TITLE
refactor: unify D1 binding name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ MIT
 Run migrations before starting the app to ensure the database schema matches the latest API routes.
 
 ```bash
-wrangler d1 migrations apply JIMI_DB
+wrangler d1 migrations apply DB
 ```
 
 This will apply `migrations/003_add_file_key_column.sql` and any earlier scripts, adding the `gallery` and `file_key` columns required by the upload and gallery APIs.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -3,7 +3,7 @@
 
 import { D1Database } from '@cloudflare/workers-types';
 
-export function getDb(env: { JIMI_DB: D1Database }) {
-  return env.JIMI_DB;
+export function getDb(env: { DB: D1Database }) {
+  return env.DB;
 }
 

--- a/pages/api/gallery.ts
+++ b/pages/api/gallery.ts
@@ -26,7 +26,7 @@ function json(data: unknown, status = 200) {
 export default async function handler(req: Request): Promise<Response> {
   try {
     const env: any = (globalThis as any)?.env ?? {};
-    const DB = env.DB ?? env.JIMI_DB;
+    const DB = env.DB;
     if (!DB?.prepare) return json({ error: "Database not configured" }, 500);
 
     if (req.method === "GET") {

--- a/pages/api/sketches.ts
+++ b/pages/api/sketches.ts
@@ -24,7 +24,7 @@ export default async function handler(req: Request): Promise<Response> {
     if (req.method !== 'GET') return new Response('Method Not Allowed', { status: 405 });
 
     const env: any = (globalThis as any)?.env ?? {};
-    const DB = env.DB ?? env.JIMI_DB;
+    const DB = env.DB;
     const R2: R2Bucket | undefined =
       env.PRISIM_R2 ?? env.BUCKET ?? env.ASSETS ?? env.PRISIM_BUCKET;
 

--- a/pages/api/uploads.ts
+++ b/pages/api/uploads.ts
@@ -14,7 +14,7 @@ export default async function handler(req: Request): Promise<Response> {
     if (req.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
 
     const env: any = (globalThis as any)?.env ?? {};
-    const DB = env.DB ?? env.JIMI_DB;
+    const DB = env.DB;
     const R2: R2Bucket | undefined =
       env.PRISIM_R2 ?? env.BUCKET ?? env.ASSETS ?? env.PRISIM_BUCKET;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -6,7 +6,7 @@ import { R2Bucket, D1Database } from '@cloudflare/workers-types';
 declare global {
   interface CloudflareEnv {
     /** Your D1 binding name */
-    JIMI_DB: D1Database;
+    DB: D1Database;
     /** Your R2 binding name */
     PRISIM_BUCKET: R2Bucket;
   }


### PR DESCRIPTION
## Summary
- consolidate database binding usage to `DB`
- update Cloudflare env types and API routes for new binding
- document migrations with `DB` binding

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Command interrupted)
- `npx wrangler d1 migrations apply DB` (fails: duplicate column name: gallery)


------
https://chatgpt.com/codex/tasks/task_e_68be221ae75c8323bb5310573b8bd7bc