### PR TITLE
Rename D1 binding to DB across configuration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The frontend interface for **Prisim**, a modern web-based media gallery. Built w
 - File upload preview
 - Sub-gallery navigation
 - Tailwind CSS styling
-- Integration-ready with Cloudflare Workers and D1
+- Integration-ready with Cloudflare Workers and a database binding (`DB`)
 
 ## Getting Started
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,5 @@
 // prisim-frontend/lib/db.ts
-// Utility for Next.js API routes to access the D1 binding
+// Utility for Next.js API routes to access the DB binding
 
 import { D1Database } from '@cloudflare/workers-types';
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -5,7 +5,7 @@ import { R2Bucket, D1Database } from '@cloudflare/workers-types';
 
 declare global {
   interface CloudflareEnv {
-    /** Your D1 binding name */
+    /** Your DB binding name */
     DB: D1Database;
     /** Your R2 binding name */
     PRISIM_BUCKET: R2Bucket;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ pages_build_output_dir = ".vercel/output/static"
 compatibility_date = "2025-07-01"
 compatibility_flags = ["nodejs_compat"]
 
-# --- D1 Database ---
+# --- DB binding ---
 [[d1_databases]]
 binding = "DB"  
 database_name = "prisim-frontend"  


### PR DESCRIPTION
## Summary
- rename comments and documentation to refer to the D1 database binding as `DB`
- clarify database binding section in `wrangler.toml`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be2778ebac832391d3c0b14ddb4ae8