### PR TITLE
Rename DB binding to JIMI_DB

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -3,7 +3,7 @@
 
 import { D1Database } from '@cloudflare/workers-types';
 
-export function getDb(env: { DB: D1Database }) {
-  return env.DB;
+export function getDb(env: { JIMI_DB: D1Database }) {
+  return env.JIMI_DB;
 }
 


### PR DESCRIPTION
## Summary
- use `JIMI_DB` binding instead of `DB` in DB utility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type error: Untyped function calls may not accept type arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68beb86737b08323bb3a3c51d4666c2a