### PR TITLE
Handle sketch metadata on upload

### DIFF
--- a/pages/api/sketches.ts
+++ b/pages/api/sketches.ts
@@ -17,7 +17,7 @@ export default async function handler(_req: Request, ctx: any) {
 
   try {
     const stmt = env.JIMI_DB.prepare(
-      `SELECT id, title, prompt, image_url, created_at
+      `SELECT id, slug, title, style, black_and_white, notes, url, gallery, created_at
        FROM sketches
        ORDER BY created_at DESC`
     );


### PR DESCRIPTION
## Summary
- Capture sketch title, style, notes, gallery, and black & white flag during uploads and persist them with a generated slug and file URL.
- Expose full sketch metadata via the `/api/sketches` endpoint for gallery display.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf081011188323a6b65cc311480069