### PR TITLE
chore: sync schema snapshot with migration

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,13 +1,113 @@
-CREATE TABLE gallery_sketches (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  slug TEXT NOT NULL UNIQUE,
-  title TEXT NOT NULL,
-  gallery TEXT NOT NULL DEFAULT 'default',
-  file_key TEXT NOT NULL,
-  style TEXT,
-  black_and_white INTEGER DEFAULT 0,
-  notes TEXT,
-  url TEXT NOT NULL,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+-- D1-safe init (no WAL/FTS). You can add FTS later as 002.sql.
+PRAGMA foreign_keys = ON;
+
+-- ===== core =====
+CREATE TABLE IF NOT EXISTS galleries (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug        TEXT UNIQUE NOT NULL,
+  title       TEXT NOT NULL,
+  description TEXT,
+  cover_url   TEXT,
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
+
+CREATE TABLE IF NOT EXISTS assets (
+  id          TEXT PRIMARY KEY,             -- uuid
+  gallery_id  INTEGER NOT NULL REFERENCES galleries(id) ON DELETE CASCADE,
+  gallery     TEXT,                         -- denormalized gallery slug
+  r2_key      TEXT NOT NULL UNIQUE,
+  file_key    TEXT,                         -- alias of r2_key
+  filename    TEXT NOT NULL,
+  mime_type   TEXT NOT NULL,
+  size_bytes  INTEGER NOT NULL DEFAULT 0,
+  width       INTEGER,
+  height      INTEGER,
+  duration_ms INTEGER,
+  title       TEXT,
+  caption     TEXT,
+  is_favorite INTEGER NOT NULL DEFAULT 0,   -- 0/1
+  kind        TEXT NOT NULL DEFAULT 'image',-- 'image'|'sketch'|'video'
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  deleted_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_assets_gallery       ON assets(gallery_id);
+CREATE INDEX IF NOT EXISTS idx_assets_gallery_slug ON assets(gallery);
+CREATE INDEX IF NOT EXISTS idx_assets_kind          ON assets(kind);
+CREATE INDEX IF NOT EXISTS idx_assets_favorite      ON assets(is_favorite) WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS tags (
+  id    INTEGER PRIMARY KEY AUTOINCREMENT,
+  name  TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS asset_tags (
+  asset_id TEXT NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+  tag_id   INTEGER NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+  PRIMARY KEY (asset_id, tag_id)
+);
+
+CREATE TABLE IF NOT EXISTS uploads (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  key          TEXT UNIQUE,
+  filename     TEXT,
+  content_type TEXT,
+  created_at   TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS sketches (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug           TEXT UNIQUE,
+  title          TEXT,
+  style          TEXT,
+  black_and_white INTEGER,
+  notes          TEXT,
+  url            TEXT,
+  gallery        TEXT,
+  created_at     TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS images (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  gallery_id  INTEGER REFERENCES galleries(id),
+  key         TEXT UNIQUE,
+  url         TEXT,
+  caption     TEXT,
+  created_at  TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_sketches_gallery ON sketches(gallery);
+CREATE INDEX IF NOT EXISTS idx_images_gallery   ON images(gallery_id);
+
+-- ===== housekeeping =====
+CREATE TRIGGER IF NOT EXISTS trg_galleries_updated_at
+AFTER UPDATE ON galleries
+BEGIN
+  UPDATE galleries
+  SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+  WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_assets_updated_at
+AFTER UPDATE ON assets
+BEGIN
+  UPDATE assets
+  SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+  WHERE id = NEW.id;
+END;
+
+-- ===== helpful view =====
+CREATE VIEW IF NOT EXISTS v_gallery_counts AS
+SELECT
+  g.id,
+  g.slug,
+  g.title,
+  COUNT(a.id) AS asset_count,
+  SUM(CASE WHEN a.is_favorite = 1 AND a.deleted_at IS NULL THEN 1 ELSE 0 END) AS favorite_count
+FROM galleries g
+LEFT JOIN assets a
+  ON a.gallery_id = g.id AND a.deleted_at IS NULL
+GROUP BY g.id, g.slug, g.title;
 


### PR DESCRIPTION
## Summary
- regenerate `schema.sql` from `migrations/001_init.sql` to keep schema snapshot in sync with migrations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf0a670b50832391fc52fe18c9ee4f