### PR TITLE
refactor: centralize env handling in API routes

### DIFF
--- a/lib/getEnv.ts
+++ b/lib/getEnv.ts
@@ -1,0 +1,3 @@
+export function getEnv<T = Record<string, unknown>>(req?: Request | any, ctx?: { env?: T }): T | undefined {
+  return (req as any)?.cf?.env ?? ctx?.env ?? (globalThis as any)?.env;
+}

--- a/pages/api/gallery.ts
+++ b/pages/api/gallery.ts
@@ -1,6 +1,8 @@
 // pages/api/gallery.ts
 // Next.js (pages router) API route running on the Edge, using Cloudflare D1 typings.
 
+import { getEnv } from '../../lib/getEnv';
+
 export const config = { runtime: 'edge' };
 
 type GalleryRow = {
@@ -14,10 +16,9 @@ type Env = {
   JIMI_DB: D1Database;
 };
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(req: Request, ctx: any): Promise<Response> {
   try {
-    // In next-on-pages, env is available on req.cf.env
-    const env = (req as any).cf?.env as Env | undefined;
+    const env = getEnv<Env>(req, ctx);
     if (!env?.JIMI_DB) {
       return json({ error: 'D1 binding JIMI_DB not available' }, 500);
     }

--- a/pages/api/sketches.ts
+++ b/pages/api/sketches.ts
@@ -1,3 +1,5 @@
+import { getEnv } from "../../lib/getEnv";
+
 export const config = { runtime: "edge" };
 
 type Env = {
@@ -12,8 +14,11 @@ function json(body: unknown, init: number | ResponseInit = 200) {
   });
 }
 
-export default async function handler(_req: Request, ctx: any) {
-  const env: Env = (ctx as any).env ?? (globalThis as any).env;
+export default async function handler(req: Request, ctx: any) {
+  const env = getEnv<Env>(req, ctx);
+  if (!env?.JIMI_DB) {
+    return json({ error: "D1 binding JIMI_DB not available" }, 500);
+  }
 
   try {
     const stmt = env.JIMI_DB.prepare(

--- a/pages/api/uploads.ts
+++ b/pages/api/uploads.ts
@@ -1,3 +1,5 @@
+import { getEnv } from "../../lib/getEnv";
+
 export const config = { runtime: "edge" };
 
 type Env = {
@@ -21,7 +23,10 @@ function slugify(input: string) {
 }
 
 export default async function handler(req: Request, ctx: any) {
-  const env: Env = (ctx as any).env ?? (globalThis as any).env;
+  const env = getEnv<Env>(req, ctx);
+  if (!env?.PRISIM_BUCKET || !env?.JIMI_DB) {
+    return json({ error: "R2 binding PRISIM_BUCKET or D1 binding JIMI_DB not available" }, 500);
+  }
 
   if (req.method !== "POST") {
     return json({ error: "Method not allowed" }, 405);


### PR DESCRIPTION
## Summary
- add helper to read runtime env bindings
- use helper in gallery, uploads, and sketches API routes with missing-binding checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf2020d94483239b1261cedd229171