### PR TITLE
feat: validate storage bindings

### DIFF
--- a/pages/api/sketches.ts
+++ b/pages/api/sketches.ts
@@ -16,11 +16,13 @@ function json(body: unknown, init: number | ResponseInit = 200) {
 
 export default async function handler(req: Request, ctx: any) {
   const env = getEnv<Env>(req, ctx);
-  if (!env?.JIMI_DB) {
-    return json({ error: "D1 binding JIMI_DB not available" }, 500);
-  }
 
   try {
+    if (!env?.JIMI_DB) {
+      console.error("missing binding", "JIMI_DB");
+      return json({ error: "missing binding" }, 500);
+    }
+
     const stmt = env.JIMI_DB.prepare(
       `SELECT id, slug, title, style, black_and_white, notes, url, gallery, created_at
        FROM sketches


### PR DESCRIPTION
## Summary
- verify PRISIM_BUCKET and JIMI_DB before storage operations and log missing bindings
- handle missing JIMI_DB in sketches API

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf231aa5ac8323891ae1c9402c4b3d